### PR TITLE
fix: Add write permissions to deploy job for GitHub Pages push

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -33,6 +33,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## 問題
Deploy ジョブが gh-pages ブランチへの push で以下エラーが発生：
```
Permission to kazweda/adaptive_control_lab.git denied to github-actions[bot]
```

## 原因
peaceiris/actions-gh-pages が gh-pages ブランチへの write 権限がない

## 修正
deploy ジョブに `permissions: { contents: write }` を追加し、GITHUB_TOKEN の write 権限を明示的に許可