### PR TITLE
feat: STR制御器UI画面の実装

### DIFF
--- a/lib/ui/controllers/str_controller_screen.dart
+++ b/lib/ui/controllers/str_controller_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../simulation/simulator.dart';
 
-/// STR制御器の設定画面（プレースホルダー）
-class STRControllerScreen extends StatelessWidget {
+/// STR制御器の設定画面
+class STRControllerScreen extends StatefulWidget {
   final Simulator simulator;
   final VoidCallback onUpdate;
 
@@ -13,16 +13,233 @@ class STRControllerScreen extends StatelessWidget {
   });
 
   @override
+  State<STRControllerScreen> createState() => _STRControllerScreenState();
+}
+
+class _STRControllerScreenState extends State<STRControllerScreen> {
+  @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Column(
+      children: [
+        _buildSTREnableSection(),
+        const SizedBox(height: 16),
+        if (widget.simulator.strEnabled) ...[
+          _buildTargetPolesSection(),
+          const SizedBox(height: 16),
+          _buildEstimatedParametersSection(),
+        ],
+      ],
+    );
+  }
+
+  /// STR有効化トグルセクション
+  Widget _buildSTREnableSection() {
+    return Card(
       child: Padding(
-        padding: EdgeInsets.all(16.0),
-        child: Text(
-          'STR制御器設定画面\n（今後実装予定）',
-          textAlign: TextAlign.center,
-          style: TextStyle(fontSize: 16, color: Colors.grey),
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'STR制御器',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                Switch(
+                  value: widget.simulator.strEnabled,
+                  onChanged: (value) {
+                    setState(() {
+                      widget.simulator.setStrEnabled(value);
+                      widget.onUpdate();
+                    });
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              widget.simulator.strEnabled
+                  ? 'STR制御有効（自動パラメータ同定）'
+                  : 'STR制御無効（PID制御のみ）',
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+          ],
         ),
       ),
+    );
+  }
+
+  /// 所望の極スライダーセクション
+  Widget _buildTargetPolesSection() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '所望の極（応答速度・安定性の調整）',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+
+            // 1次・2次共通: targetPole1
+            _buildPoleSlider(
+              label: '主極（極1）',
+              value: widget.simulator.strTargetPole1,
+              onChanged: (value) {
+                setState(() {
+                  widget.simulator.setStrTargetPoles(
+                    value,
+                    widget.simulator.strTargetPole2,
+                  );
+                  widget.onUpdate();
+                });
+              },
+              description: '小さいほど速く減衰（0 < p < 1）',
+            ),
+            const SizedBox(height: 16),
+
+            // 2次系のみ表示
+            if (widget.simulator.isSecondOrderPlant)
+              Column(
+                children: [
+                  _buildPoleSlider(
+                    label: '補助極（極2）',
+                    value: widget.simulator.strTargetPole2,
+                    onChanged: (value) {
+                      setState(() {
+                        widget.simulator.setStrTargetPoles(
+                          widget.simulator.strTargetPole1,
+                          value,
+                        );
+                        widget.onUpdate();
+                      });
+                    },
+                    description: '2次プラント用の補助極',
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              ),
+
+            // Butterworth配置ボタン（2次系のみ）
+            if (widget.simulator.isSecondOrderPlant)
+              ElevatedButton.icon(
+                onPressed: () {
+                  setState(() {
+                    widget.simulator.str?.setTargetPolesButterworth(0.3);
+                    widget.onUpdate();
+                  });
+                },
+                icon: const Icon(Icons.tune),
+                label: const Text('Butterworth配置（推奨）'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blue[300],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 極スライダーのヘルパーウィジェット
+  Widget _buildPoleSlider({
+    required String label,
+    required double value,
+    required ValueChanged<double> onChanged,
+    required String description,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+            ),
+            Text(
+              value.toStringAsFixed(3),
+              style: const TextStyle(fontSize: 13),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          description,
+          style: const TextStyle(fontSize: 11, color: Colors.grey),
+        ),
+        const SizedBox(height: 8),
+        Slider(
+          value: value,
+          min: 0.01,
+          max: 0.99,
+          divisions: 98,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+
+  /// 推定パラメータ表示セクション
+  Widget _buildEstimatedParametersSection() {
+    final str = widget.simulator.str;
+    if (str == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '推定パラメータ（RLS同定）',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+
+            if (str.parameterCount == 2) ...[
+              // 1次系
+              _buildParameterRow('a（自己回帰係数）', str.estimatedA),
+              const SizedBox(height: 8),
+              _buildParameterRow('b（入力係数）', str.estimatedB),
+            ] else if (str.parameterCount == 4) ...[
+              // 2次系
+              _buildParameterRow('a1（y(k-1)の係数）', str.estimatedA1),
+              const SizedBox(height: 8),
+              _buildParameterRow('a2（y(k-2)の係数）', str.estimatedA2),
+              const SizedBox(height: 8),
+              _buildParameterRow('b1（u(k-1)の係数）', str.estimatedB1),
+              const SizedBox(height: 8),
+              _buildParameterRow('b2（u(k-2)の係数）', str.estimatedB2),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// パラメータ行のヘルパーウィジェット
+  Widget _buildParameterRow(String label, double value) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label, style: const TextStyle(fontSize: 13)),
+        Text(
+          value.toStringAsFixed(4),
+          style: const TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.bold,
+            fontFamily: 'monospace',
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/controllers/str_controller_screen.dart
+++ b/lib/ui/controllers/str_controller_screen.dart
@@ -130,6 +130,13 @@ class _STRControllerScreenState extends State<STRControllerScreen> {
                 onPressed: () {
                   setState(() {
                     widget.simulator.str?.setTargetPolesButterworth(0.3);
+                    // STR オブジェクトの極を Simulator のプロパティに同期
+                    if (widget.simulator.str != null) {
+                      widget.simulator.setStrTargetPoles(
+                        widget.simulator.str!.targetPole1,
+                        widget.simulator.str!.targetPole2,
+                      );
+                    }
                     widget.onUpdate();
                   });
                 },

--- a/test/ui/controllers_test.dart
+++ b/test/ui/controllers_test.dart
@@ -97,7 +97,7 @@ void main() {
       simulator = Simulator();
     });
 
-    testWidgets('プレースホルダーテキストが表示される', (WidgetTester tester) async {
+    testWidgets('STR有効化トグルが表示される', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -106,11 +106,14 @@ void main() {
         ),
       );
 
-      // プレースホルダーテキストが表示される
-      expect(find.text('STR制御器設定画面\n（今後実装予定）'), findsOneWidget);
+      // STR制御器トグルテキストが表示される
+      expect(find.text('STR制御器'), findsOneWidget);
+      // Switchが表示されている
+      expect(find.byType(Switch), findsOneWidget);
     });
 
-    testWidgets('Centerウィジェットで中央配置される', (WidgetTester tester) async {
+    testWidgets('STR有効時に極スライダーが表示される', (WidgetTester tester) async {
+      simulator.setStrEnabled(true);
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -119,8 +122,8 @@ void main() {
         ),
       );
 
-      // Centerウィジェットが使われている
-      expect(find.byType(Center), findsOneWidget);
+      // 主極スライダーラベルが表示される
+      expect(find.text('主極（極1）'), findsOneWidget);
     });
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -135,8 +135,8 @@ void main() {
     await tester.tap(find.text('STR制御'));
     await tester.pump();
 
-    // STR画面のプレースホルダーテキストが表示される
-    expect(find.text('STR制御器設定画面\n（今後実装予定）'), findsOneWidget);
+    // STR画面のSTR制御器トグルが表示される
+    expect(find.text('STR制御器'), findsOneWidget);
 
     // PIDゲイン調整は表示されない
     expect(find.text('PID ゲイン調整'), findsNothing);


### PR DESCRIPTION
## 実装内容

Issue #30の完了。STR制御器のUI画面を実装しました。

### 機能

- **STR有効化トグル**: STR制御器のオン/オフ切り替え
- **所望極スライダー**: 1次・2次プラント対応
  - 主極（極1）: 0.01〜0.99で調整可能
  - 補助極（極2）: 2次プラントのみ
- **Butterworth配置ボタン**: 推奨設定を1クリックで適用（2次系のみ）
- **推定パラメータ表示**: RLSにより同定されたプラントパラメータをリアルタイム表示
  - 1次系: a, b
  - 2次系: a1, a2, b1, b2

### テスト

- STR有効化トグル表示確認
- STR有効時の極スライダー表示確認
- 既存プレースホルダーテストを実装テストに更新
- 全テストパス

## 動作確認

- [x] flutter analyze - エラーなし
- [x] flutter test - 全テストパス
- [x] コントローラー選択タブで切り替え可能

Implements #30
