### PR TITLE
feat: implement HistoryManager to separate history management from Simulator

### DIFF
--- a/lib/simulation/disturbance_manager.dart
+++ b/lib/simulation/disturbance_manager.dart
@@ -1,0 +1,222 @@
+import '../control/disturbance.dart';
+
+/// 外乱プリセットの定義
+class DisturbancePreset {
+  final String name;
+  final String displayName;
+  final DisturbanceType type;
+  final double amplitude;
+  final int startStep;
+  final double omega;
+  final double phase;
+  final double noiseStdDev;
+  final int noiseSeed;
+
+  DisturbancePreset({
+    required this.name,
+    required this.displayName,
+    required this.type,
+    this.amplitude = 0.0,
+    this.startStep = 0,
+    this.omega = 0.0,
+    this.phase = 0.0,
+    this.noiseStdDev = 0.0,
+    this.noiseSeed = 42,
+  });
+
+  /// プリセットから Disturbance を生成
+  Disturbance toDisturbance() {
+    switch (type) {
+      case DisturbanceType.none:
+        return Disturbance(type: DisturbanceType.none);
+      case DisturbanceType.step:
+        return Disturbance(
+          type: DisturbanceType.step,
+          amplitude: amplitude,
+          startStep: startStep,
+        );
+      case DisturbanceType.impulse:
+        return Disturbance(
+          type: DisturbanceType.impulse,
+          amplitude: amplitude,
+          startStep: startStep,
+        );
+      case DisturbanceType.sinusoid:
+        return Disturbance(
+          type: DisturbanceType.sinusoid,
+          amplitude: amplitude,
+          omega: omega,
+          phase: phase,
+        );
+      case DisturbanceType.noise:
+        return Disturbance(
+          type: DisturbanceType.noise,
+          noiseStdDev: noiseStdDev,
+          noiseSeed: noiseSeed,
+        );
+    }
+  }
+}
+
+/// 外乱管理の責務を分離（Simulator から委譲）
+class DisturbanceManager {
+  Disturbance? disturbance;
+  String currentPresetName = 'なし';
+
+  /// コンストラクタ
+  DisturbanceManager() {
+    disturbance = Disturbance(type: DisturbanceType.none);
+  }
+
+  /// プリセット一覧を取得
+  static List<DisturbancePreset> getAvailablePresets() {
+    return [
+      DisturbancePreset(
+        name: 'none',
+        displayName: 'なし',
+        type: DisturbanceType.none,
+      ),
+      DisturbancePreset(
+        name: 'step_early',
+        displayName: 'ステップ外乱（早期）',
+        type: DisturbanceType.step,
+        amplitude: 0.2,
+        startStep: 10,
+      ),
+      DisturbancePreset(
+        name: 'step_mid',
+        displayName: 'ステップ外乱（中期）',
+        type: DisturbanceType.step,
+        amplitude: 0.2,
+        startStep: 100,
+      ),
+      DisturbancePreset(
+        name: 'step_large',
+        displayName: 'ステップ外乱（大信号）',
+        type: DisturbanceType.step,
+        amplitude: 0.5,
+        startStep: 100,
+      ),
+      DisturbancePreset(
+        name: 'impulse_small',
+        displayName: 'インパルス外乱（小）',
+        type: DisturbanceType.impulse,
+        amplitude: 0.3,
+        startStep: 50,
+      ),
+      DisturbancePreset(
+        name: 'impulse_large',
+        displayName: 'インパルス外乱（大）',
+        type: DisturbanceType.impulse,
+        amplitude: 1.0,
+        startStep: 100,
+      ),
+      DisturbancePreset(
+        name: 'sinusoid_slow',
+        displayName: '正弦波（低周波）',
+        type: DisturbanceType.sinusoid,
+        amplitude: 0.2,
+        omega: 0.05,
+        phase: 0.0,
+      ),
+      DisturbancePreset(
+        name: 'sinusoid_mid',
+        displayName: '正弦波（中周波）',
+        type: DisturbanceType.sinusoid,
+        amplitude: 0.2,
+        omega: 0.2,
+        phase: 0.0,
+      ),
+      DisturbancePreset(
+        name: 'sinusoid_fast',
+        displayName: '正弦波（高周波）',
+        type: DisturbanceType.sinusoid,
+        amplitude: 0.15,
+        omega: 0.5,
+        phase: 0.0,
+      ),
+      DisturbancePreset(
+        name: 'noise_small',
+        displayName: 'ガウス雑音（小）',
+        type: DisturbanceType.noise,
+        noiseStdDev: 0.03,
+        noiseSeed: 42,
+      ),
+      DisturbancePreset(
+        name: 'noise_mid',
+        displayName: 'ガウス雑音（中）',
+        type: DisturbanceType.noise,
+        noiseStdDev: 0.05,
+        noiseSeed: 42,
+      ),
+      DisturbancePreset(
+        name: 'noise_large',
+        displayName: 'ガウス雑音（大）',
+        type: DisturbanceType.noise,
+        noiseStdDev: 0.1,
+        noiseSeed: 42,
+      ),
+    ];
+  }
+
+  /// プリセットを適用
+  void applyPreset(String presetName) {
+    final preset = getAvailablePresets().firstWhere(
+      (p) => p.name == presetName,
+      orElse: () => getAvailablePresets().first,
+    );
+    disturbance = preset.toDisturbance();
+    currentPresetName = preset.displayName;
+  }
+
+  /// 外乱タイプを設定（カスタム設定）
+  void setType(DisturbanceType type) {
+    disturbance = _createDefaultDisturbance(type);
+    currentPresetName = 'Custom';
+  }
+
+  /// 外乱タイプを取得
+  DisturbanceType getType() => disturbance?.type ?? DisturbanceType.none;
+
+  /// 次ステップの外乱値を取得
+  double getNext() => disturbance?.next() ?? 0.0;
+
+  /// リセット
+  void reset() {
+    disturbance?.reset();
+    currentPresetName = 'なし';
+  }
+
+  /// デフォルト外乱を生成（タイプ別）
+  static Disturbance _createDefaultDisturbance(DisturbanceType type) {
+    switch (type) {
+      case DisturbanceType.none:
+        return Disturbance(type: DisturbanceType.none);
+      case DisturbanceType.step:
+        return Disturbance(
+          type: DisturbanceType.step,
+          amplitude: 0.2,
+          startStep: 50,
+        );
+      case DisturbanceType.impulse:
+        return Disturbance(
+          type: DisturbanceType.impulse,
+          amplitude: 0.5,
+          startStep: 30,
+        );
+      case DisturbanceType.sinusoid:
+        return Disturbance(
+          type: DisturbanceType.sinusoid,
+          amplitude: 0.2,
+          omega: 0.2,
+          phase: 0.0,
+        );
+      case DisturbanceType.noise:
+        return Disturbance(
+          type: DisturbanceType.noise,
+          noiseStdDev: 0.05,
+          noiseSeed: 42,
+        );
+    }
+  }
+}

--- a/lib/simulation/disturbance_manager.dart
+++ b/lib/simulation/disturbance_manager.dart
@@ -58,7 +58,31 @@ class DisturbancePreset {
   }
 }
 
-/// 外乱管理の責務を分離（Simulator から委譲）
+/// 外乱管理クラス
+///
+/// Simulator が扱う外乱状態と外乱プリセット選択の責務をこのクラスに委譲します。
+/// 現在有効な [Disturbance] インスタンスと、ユーザーが選択したプリセット名を保持し、
+/// UIからの操作に応じて外乱を切り替えるためのユーティリティを提供します。
+///
+/// ## 役割
+/// - 外乱の現在状態（disturbance）を保持
+/// - 外乱プリセットの一覧（[getAvailablePresets]）を提供
+/// - プリセット名から対応する [DisturbancePreset] を選択し、[Disturbance] を生成
+/// - currentPresetName を更新してUIで選択中のプリセットを表示できるようにする
+///
+/// ## Simulator との関係
+/// Simulator は本クラスのインスタンスを1つ保持し、シミュレーションステップごとに
+/// disturbance?.next() を通じて外乱値を取得します。
+/// 外乱の切り替え（プリセット/カスタム）はすべて DisturbanceManager を経由して行い、
+/// Simulator 本体の責務（制御ループや履歴管理）から外乱ロジックを分離しています。
+///
+/// ## プリセットとカスタム設定の違い
+/// - **プリセット適用**: applyPreset('noise_mid') のようにプリセット名で指定すると、
+///   あらかじめ定義されたパラメータ（振幅、開始ステップ、周波数、ノイズ分散、乱数シードなど）で
+///   Disturbance が再生成されます。再現性のあるシナリオ比較に適しています。
+/// - **カスタム設定**: setType(DisturbanceType.sinusoid) のようにタイプのみを変更する場合、
+///   currentPresetName は 'Custom' に更新され、「プリセットではない状態」を表します。
+///   これによりUIで「プリセット由来の設定」か「手動調整した設定」かを区別できます。
 class DisturbanceManager {
   Disturbance? disturbance;
   String currentPresetName = 'なし';

--- a/lib/simulation/history_manager.dart
+++ b/lib/simulation/history_manager.dart
@@ -1,0 +1,106 @@
+/// シミュレーションデータの履歴管理クラス
+///
+/// 目標値、出力値、制御入力、RLS推定値の履歴を管理し、
+/// 自動トリミングによるメモリ保護を提供する。
+class HistoryManager {
+  /// 履歴の最大長（メモリ/パフォーマンス保護用）
+  final int maxLength;
+
+  // 基本履歴（全シミュレーションで使用）
+  List<double> target = [];
+  List<double> output = [];
+  List<double> control = [];
+
+  // 1次プラント用のRLS推定値履歴
+  List<double> estimatedA = [];
+  List<double> estimatedB = [];
+
+  // 2次プラント用のRLS推定値履歴
+  List<double> estimatedA1 = [];
+  List<double> estimatedA2 = [];
+  List<double> estimatedB1 = [];
+  List<double> estimatedB2 = [];
+
+  /// コンストラクタ
+  HistoryManager({this.maxLength = 5000});
+
+  /// 基本履歴（目標値、出力、制御入力）を追加
+  void addStep({
+    required double targetValue,
+    required double outputValue,
+    required double controlValue,
+  }) {
+    target.add(targetValue);
+    output.add(outputValue);
+    control.add(controlValue);
+
+    // 自動トリミング（基本履歴のみチェック）
+    if (target.length > maxLength) {
+      target.removeAt(0);
+      output.removeAt(0);
+      control.removeAt(0);
+    }
+  }
+
+  /// 1次プラント用のRLS推定値を追加
+  void addFirstOrderEstimates({required double a, required double b}) {
+    estimatedA.add(a);
+    estimatedB.add(b);
+
+    // 自動トリミング
+    if (estimatedA.length > maxLength) {
+      estimatedA.removeAt(0);
+      estimatedB.removeAt(0);
+    }
+  }
+
+  /// 2次プラント用のRLS推定値を追加
+  void addSecondOrderEstimates({
+    required double a1,
+    required double a2,
+    required double b1,
+    required double b2,
+  }) {
+    estimatedA1.add(a1);
+    estimatedA2.add(a2);
+    estimatedB1.add(b1);
+    estimatedB2.add(b2);
+
+    // 自動トリミング
+    if (estimatedA1.length > maxLength) {
+      estimatedA1.removeAt(0);
+      estimatedA2.removeAt(0);
+      estimatedB1.removeAt(0);
+      estimatedB2.removeAt(0);
+    }
+  }
+
+  /// 全履歴をクリア
+  void clearAll() {
+    target.clear();
+    output.clear();
+    control.clear();
+    clearRlsEstimates();
+  }
+
+  /// RLS推定値履歴のみクリア
+  void clearRlsEstimates() {
+    estimatedA.clear();
+    estimatedB.clear();
+    estimatedA1.clear();
+    estimatedA2.clear();
+    estimatedB1.clear();
+    estimatedB2.clear();
+  }
+
+  /// 履歴のステップ数を取得
+  int get length => target.length;
+
+  /// デバッグ用の文字列表現
+  @override
+  String toString() {
+    return 'HistoryManager(length: $length/$maxLength, '
+        'hasRlsFirstOrder: ${estimatedA.isNotEmpty}, '
+        'hasRlsSecondOrder: ${estimatedA1.isNotEmpty})';
+  }
+}

--- a/lib/simulation/pid_manager.dart
+++ b/lib/simulation/pid_manager.dart
@@ -1,0 +1,48 @@
+import '../control/pid.dart';
+
+/// PID制御の責務を分離（Simulator から委譲）
+class PIDManager {
+  late PIDController pidController;
+
+  /// コンストラクタ
+  PIDManager(PIDController initialController) {
+    pidController = initialController;
+  }
+
+  /// 誤差から制御入力を計算
+  double computeControl(double error) {
+    return pidController.compute(error);
+  }
+
+  // === PIDゲイン アクセサ ===
+
+  double get kp => pidController.kp;
+  set kp(double value) => pidController.kp = value;
+
+  double get ki => pidController.ki;
+  set ki(double value) => pidController.ki = value;
+
+  double get kd => pidController.kd;
+  set kd(double value) => pidController.kd = value;
+
+  /// コントローラーをリセット
+  void reset() => pidController.reset();
+
+  /// 1次プラント向けの標準PIDゲインを作成
+  static PIDController createFirstOrderDefault() {
+    return PIDController(kp: 0.3, ki: 0.1, kd: 0.1);
+  }
+
+  /// 2次プラント向けの標準PIDゲインを作成
+  static PIDController createSecondOrderDefault() {
+    // 2次プラントはより抑えめのゲインで初期化（発散防止）
+    return PIDController(kp: 0.12, ki: 0.02, kd: 0.04);
+  }
+
+  /// プラント次数に応じてコントローラーを初期化
+  static PIDController createForPlantOrder({required bool useSecondOrder}) {
+    return useSecondOrder
+        ? createSecondOrderDefault()
+        : createFirstOrderDefault();
+  }
+}

--- a/lib/simulation/pid_manager.dart
+++ b/lib/simulation/pid_manager.dart
@@ -1,6 +1,23 @@
 import '../control/pid.dart';
 
-/// PID制御の責務を分離（Simulator から委譲）
+/// PID制御ロジックを `Simulator` から切り離して管理するクラス
+///
+/// Simulator からPID制御器の生成・保持・リセットとPIDゲインの参照/更新の責務を委譲されます。
+/// これにより、Simulator は制御対象プラントや外乱の管理に集中でき、
+/// PID制御の詳細な実装はこのクラスに集約されます。
+///
+/// ## 主な責務
+/// - 現在使用中の [PIDController] インスタンスを保持し、そのライフサイクルを管理
+/// - 誤差 e(k) から制御入力 u(k) を計算する [computeControl] を提供
+/// - kp, ki, kd のゲインをゲッター/セッターとして公開
+/// - シミュレーションのリスタート時に [reset] でPID内部状態をクリア
+///
+/// ## 静的ファクトリメソッドの使い分け
+/// - [createFirstOrderDefault]: 1次プラントモデル向けの標準的なPIDゲイン
+/// - [createSecondOrderDefault]: 2次プラント向けに発散を避けるため抑えめのゲイン
+///
+/// これらは初期値（プリセット）であり、実際のチューニングは
+/// シミュレーション結果を見ながらゲインを動的に変更して行います。
 class PIDManager {
   late PIDController pidController;
 
@@ -37,12 +54,5 @@ class PIDManager {
   static PIDController createSecondOrderDefault() {
     // 2次プラントはより抑えめのゲインで初期化（発散防止）
     return PIDController(kp: 0.12, ki: 0.02, kd: 0.04);
-  }
-
-  /// プラント次数に応じてコントローラーを初期化
-  static PIDController createForPlantOrder({required bool useSecondOrder}) {
-    return useSecondOrder
-        ? createSecondOrderDefault()
-        : createFirstOrderDefault();
   }
 }

--- a/test/simulation/disturbance_manager_test.dart
+++ b/test/simulation/disturbance_manager_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:adaptive_control_lab/simulation/disturbance_manager.dart';
+import 'package:adaptive_control_lab/control/disturbance.dart';
+
+void main() {
+  group('DisturbanceManager', () {
+    late DisturbanceManager manager;
+
+    setUp(() {
+      manager = DisturbanceManager();
+    });
+
+    test('初期状態は外乱なし', () {
+      expect(manager.getType(), DisturbanceType.none);
+      expect(manager.currentPresetName, 'なし');
+      expect(manager.getNext(), 0.0);
+    });
+
+    test('getAvailablePresets は12個のプリセットを返す', () {
+      final presets = DisturbanceManager.getAvailablePresets();
+      expect(presets.length, 12);
+    });
+
+    test('全プリセット名が想定通り', () {
+      final presets = DisturbanceManager.getAvailablePresets();
+      final names = presets.map((p) => p.name).toList();
+
+      expect(names, contains('none'));
+      expect(names, contains('step_early'));
+      expect(names, contains('step_mid'));
+      expect(names, contains('step_large'));
+      expect(names, contains('impulse_small'));
+      expect(names, contains('impulse_large'));
+      expect(names, contains('sinusoid_slow'));
+      expect(names, contains('sinusoid_mid'));
+      expect(names, contains('sinusoid_fast'));
+      expect(names, contains('noise_small'));
+      expect(names, contains('noise_mid'));
+      expect(names, contains('noise_large'));
+    });
+
+    test('applyPreset で none を適用', () {
+      manager.applyPreset('none');
+      expect(manager.getType(), DisturbanceType.none);
+      expect(manager.currentPresetName, 'なし');
+      expect(manager.getNext(), 0.0);
+    });
+
+    test('applyPreset で step_mid を適用', () {
+      manager.applyPreset('step_mid');
+      expect(manager.getType(), DisturbanceType.step);
+      expect(manager.currentPresetName, 'ステップ外乱（中期）');
+    });
+
+    test('applyPreset で noise_mid を適用', () {
+      manager.applyPreset('noise_mid');
+      expect(manager.getType(), DisturbanceType.noise);
+      expect(manager.currentPresetName, 'ガウス雑音（中）');
+
+      // ノイズはランダム値を返す（0以外）
+      final noise = manager.getNext();
+      expect(noise, isA<double>());
+    });
+
+    test('setType でカスタム外乱タイプを設定', () {
+      manager.setType(DisturbanceType.sinusoid);
+      expect(manager.getType(), DisturbanceType.sinusoid);
+      expect(manager.currentPresetName, 'Custom');
+    });
+
+    test('setType 後に getNext で値を取得できる', () {
+      manager.setType(DisturbanceType.step);
+
+      // ステップ外乱は startStep 前は0
+      for (int i = 0; i < 50; i++) {
+        manager.getNext();
+      }
+
+      // startStep 後は amplitude の値
+      final value = manager.getNext();
+      expect(value, isA<double>());
+    });
+
+    test('reset で外乱状態がリセットされる', () {
+      manager.applyPreset('step_mid');
+
+      // 複数回呼び出してステップカウンタを進める
+      for (int i = 0; i < 100; i++) {
+        manager.getNext();
+      }
+
+      manager.reset();
+      expect(manager.currentPresetName, 'なし');
+    });
+
+    test('存在しないプリセット名を指定すると none にフォールバック', () {
+      manager.applyPreset('invalid_preset');
+      expect(manager.getType(), DisturbanceType.none);
+    });
+
+    test('プリセット適用後にタイプ変更するとカスタムになる', () {
+      manager.applyPreset('step_mid');
+      expect(manager.currentPresetName, 'ステップ外乱（中期）');
+
+      manager.setType(DisturbanceType.impulse);
+      expect(manager.currentPresetName, 'Custom');
+      expect(manager.getType(), DisturbanceType.impulse);
+    });
+
+    test('異なるプリセットを連続で適用できる', () {
+      manager.applyPreset('noise_small');
+      expect(manager.currentPresetName, 'ガウス雑音（小）');
+
+      manager.applyPreset('sinusoid_fast');
+      expect(manager.currentPresetName, '正弦波（高周波）');
+      expect(manager.getType(), DisturbanceType.sinusoid);
+    });
+
+    test('DisturbancePreset の toDisturbance が正しく動作', () {
+      final presets = DisturbanceManager.getAvailablePresets();
+
+      for (final preset in presets) {
+        final disturbance = preset.toDisturbance();
+        expect(disturbance.type, preset.type);
+      }
+    });
+
+    test('step 外乱プリセットのパラメータ確認', () {
+      final presets = DisturbanceManager.getAvailablePresets();
+      final stepEarly = presets.firstWhere((p) => p.name == 'step_early');
+
+      expect(stepEarly.type, DisturbanceType.step);
+      expect(stepEarly.amplitude, 0.2);
+      expect(stepEarly.startStep, 10);
+    });
+
+    test('noise 外乱プリセットは固定シードで再現性あり', () {
+      final presets = DisturbanceManager.getAvailablePresets();
+      final noiseMid = presets.firstWhere((p) => p.name == 'noise_mid');
+
+      expect(noiseMid.type, DisturbanceType.noise);
+      expect(noiseMid.noiseSeed, 42); // 再現性のための固定シード
+    });
+
+    test('sinusoid 外乱プリセットのパラメータ確認', () {
+      final presets = DisturbanceManager.getAvailablePresets();
+      final sinusoidSlow = presets.firstWhere((p) => p.name == 'sinusoid_slow');
+
+      expect(sinusoidSlow.type, DisturbanceType.sinusoid);
+      expect(sinusoidSlow.omega, 0.05);
+    });
+  });
+
+  group('DisturbancePreset', () {
+    test('toDisturbance は各タイプで正しい Disturbance を生成', () {
+      final nonePreset = DisturbancePreset(
+        name: 'test_none',
+        displayName: 'Test None',
+        type: DisturbanceType.none,
+      );
+
+      final disturbance = nonePreset.toDisturbance();
+      expect(disturbance.type, DisturbanceType.none);
+    });
+  });
+}

--- a/test/simulation/history_manager_test.dart
+++ b/test/simulation/history_manager_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:adaptive_control_lab/simulation/history_manager.dart';
+
+void main() {
+  group('HistoryManager', () {
+    late HistoryManager history;
+
+    setUp(() {
+      history = HistoryManager(maxLength: 10);
+    });
+
+    test('初期状態では全履歴が空', () {
+      expect(history.length, 0);
+      expect(history.target, isEmpty);
+      expect(history.output, isEmpty);
+      expect(history.control, isEmpty);
+      expect(history.estimatedA, isEmpty);
+      expect(history.estimatedB, isEmpty);
+      expect(history.estimatedA1, isEmpty);
+      expect(history.estimatedA2, isEmpty);
+      expect(history.estimatedB1, isEmpty);
+      expect(history.estimatedB2, isEmpty);
+    });
+
+    test('addStep で基本履歴が追加される', () {
+      history.addStep(targetValue: 1.0, outputValue: 0.5, controlValue: 0.3);
+
+      expect(history.length, 1);
+      expect(history.target, [1.0]);
+      expect(history.output, [0.5]);
+      expect(history.control, [0.3]);
+    });
+
+    test('addFirstOrderEstimates で1次推定値が追加される', () {
+      history.addFirstOrderEstimates(a: 0.8, b: 0.5);
+
+      expect(history.estimatedA, [0.8]);
+      expect(history.estimatedB, [0.5]);
+      expect(history.estimatedA1, isEmpty); // 2次は空のまま
+    });
+
+    test('addSecondOrderEstimates で2次推定値が追加される', () {
+      history.addSecondOrderEstimates(a1: 0.9, a2: -0.2, b1: 0.4, b2: 0.1);
+
+      expect(history.estimatedA1, [0.9]);
+      expect(history.estimatedA2, [-0.2]);
+      expect(history.estimatedB1, [0.4]);
+      expect(history.estimatedB2, [0.1]);
+      expect(history.estimatedA, isEmpty); // 1次は空のまま
+    });
+
+    test('maxLength を超えると自動トリミング（基本履歴）', () {
+      // maxLength=10 なので 11個追加すると最古の1個が削除される
+      for (int i = 0; i < 11; i++) {
+        history.addStep(
+          targetValue: i.toDouble(),
+          outputValue: i.toDouble() + 0.1,
+          controlValue: i.toDouble() + 0.2,
+        );
+      }
+
+      expect(history.length, 10);
+      expect(history.target.first, 1.0); // 0.0 が削除されて 1.0 が先頭
+      expect(history.target.last, 10.0);
+    });
+
+    test('maxLength を超えると自動トリミング（1次推定値）', () {
+      for (int i = 0; i < 11; i++) {
+        history.addFirstOrderEstimates(a: i.toDouble(), b: i.toDouble() + 0.5);
+      }
+
+      expect(history.estimatedA.length, 10);
+      expect(history.estimatedA.first, 1.0); // 0.0 が削除
+      expect(history.estimatedB.first, 1.5);
+    });
+
+    test('maxLength を超えると自動トリミング（2次推定値）', () {
+      for (int i = 0; i < 11; i++) {
+        history.addSecondOrderEstimates(
+          a1: i.toDouble(),
+          a2: i.toDouble() + 0.1,
+          b1: i.toDouble() + 0.2,
+          b2: i.toDouble() + 0.3,
+        );
+      }
+
+      expect(history.estimatedA1.length, 10);
+      expect(history.estimatedA1.first, 1.0); // 0.0 が削除
+      expect(history.estimatedA2.first, 1.1);
+      expect(history.estimatedB1.first, 1.2);
+      expect(history.estimatedB2.first, 1.3);
+    });
+
+    test('clearAll で全履歴がクリアされる', () {
+      history.addStep(targetValue: 1.0, outputValue: 0.5, controlValue: 0.3);
+      history.addFirstOrderEstimates(a: 0.8, b: 0.5);
+      history.addSecondOrderEstimates(a1: 0.9, a2: -0.2, b1: 0.4, b2: 0.1);
+
+      history.clearAll();
+
+      expect(history.length, 0);
+      expect(history.target, isEmpty);
+      expect(history.output, isEmpty);
+      expect(history.control, isEmpty);
+      expect(history.estimatedA, isEmpty);
+      expect(history.estimatedB, isEmpty);
+      expect(history.estimatedA1, isEmpty);
+      expect(history.estimatedA2, isEmpty);
+      expect(history.estimatedB1, isEmpty);
+      expect(history.estimatedB2, isEmpty);
+    });
+
+    test('clearRlsEstimates でRLS推定値のみクリアされる', () {
+      history.addStep(targetValue: 1.0, outputValue: 0.5, controlValue: 0.3);
+      history.addFirstOrderEstimates(a: 0.8, b: 0.5);
+      history.addSecondOrderEstimates(a1: 0.9, a2: -0.2, b1: 0.4, b2: 0.1);
+
+      history.clearRlsEstimates();
+
+      // 基本履歴は残る
+      expect(history.length, 1);
+      expect(history.target, [1.0]);
+      expect(history.output, [0.5]);
+      expect(history.control, [0.3]);
+
+      // RLS推定値はクリアされる
+      expect(history.estimatedA, isEmpty);
+      expect(history.estimatedB, isEmpty);
+      expect(history.estimatedA1, isEmpty);
+      expect(history.estimatedA2, isEmpty);
+      expect(history.estimatedB1, isEmpty);
+      expect(history.estimatedB2, isEmpty);
+    });
+
+    test('toString はデバッグ情報を含む', () {
+      history.addStep(targetValue: 1.0, outputValue: 0.5, controlValue: 0.3);
+      history.addFirstOrderEstimates(a: 0.8, b: 0.5);
+
+      final str = history.toString();
+      expect(str, contains('length: 1/10'));
+      expect(str, contains('hasRlsFirstOrder: true'));
+      expect(str, contains('hasRlsSecondOrder: false'));
+    });
+
+    test('基本履歴とRLS推定値の長さは独立して管理される', () {
+      // 基本履歴を3ステップ追加
+      for (int i = 0; i < 3; i++) {
+        history.addStep(
+          targetValue: i.toDouble(),
+          outputValue: i.toDouble(),
+          controlValue: i.toDouble(),
+        );
+      }
+
+      // RLS推定値を5ステップ追加（基本履歴とは非同期）
+      for (int i = 0; i < 5; i++) {
+        history.addFirstOrderEstimates(a: i.toDouble(), b: i.toDouble());
+      }
+
+      expect(history.length, 3);
+      expect(history.estimatedA.length, 5);
+      expect(history.estimatedB.length, 5);
+    });
+  });
+}

--- a/test/simulation/pid_manager_test.dart
+++ b/test/simulation/pid_manager_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:adaptive_control_lab/simulation/pid_manager.dart';
+import 'package:adaptive_control_lab/control/pid.dart';
+
+void main() {
+  group('PIDManager', () {
+    late PIDManager manager;
+
+    setUp(() {
+      manager = PIDManager(PIDController(kp: 0.5, ki: 0.1, kd: 0.05));
+    });
+
+    test('初期状態でゲインが正しく設定される', () {
+      expect(manager.kp, 0.5);
+      expect(manager.ki, 0.1);
+      expect(manager.kd, 0.05);
+    });
+
+    test('computeControl で制御入力を計算', () {
+      final control1 = manager.computeControl(1.0);
+      expect(control1, isNotNull);
+
+      // 2回目の呼び出しで積分項が蓄積される
+      final control2 = manager.computeControl(1.0);
+      expect(control2, greaterThan(control1));
+    });
+
+    test('ゲインの変更が反映される', () {
+      manager.kp = 1.0;
+      manager.ki = 0.5;
+      manager.kd = 0.2;
+
+      expect(manager.kp, 1.0);
+      expect(manager.ki, 0.5);
+      expect(manager.kd, 0.2);
+    });
+
+    test('reset でPID内部状態がクリアされる', () {
+      // 誤差を与えて積分項を蓄積
+      manager.computeControl(1.0);
+      manager.computeControl(1.0);
+      final beforeReset = manager.computeControl(0.0);
+
+      // リセット後、同じ誤差で計算
+      manager.reset();
+      final afterReset = manager.computeControl(0.0);
+
+      // 積分項がクリアされるため、リセット後の出力は異なる
+      expect(afterReset, isNot(equals(beforeReset)));
+    });
+
+    test('createFirstOrderDefault は1次プラント向けゲインを生成', () {
+      final pid = PIDManager.createFirstOrderDefault();
+      expect(pid.kp, 0.3);
+      expect(pid.ki, 0.1);
+      expect(pid.kd, 0.1);
+    });
+
+    test('createSecondOrderDefault は2次プラント向けゲインを生成', () {
+      final pid = PIDManager.createSecondOrderDefault();
+      expect(pid.kp, 0.12);
+      expect(pid.ki, 0.02);
+      expect(pid.kd, 0.04);
+    });
+
+    test('createSecondOrderDefault は createFirstOrderDefault より控えめ', () {
+      final first = PIDManager.createFirstOrderDefault();
+      final second = PIDManager.createSecondOrderDefault();
+
+      expect(second.kp, lessThan(first.kp));
+      expect(second.ki, lessThan(first.ki));
+      expect(second.kd, lessThan(first.kd));
+    });
+
+    test('異なる初期ゲインでPIDManagerを生成できる', () {
+      final manager1 = PIDManager(PIDManager.createFirstOrderDefault());
+      final manager2 = PIDManager(PIDManager.createSecondOrderDefault());
+
+      expect(manager1.kp, isNot(equals(manager2.kp)));
+      expect(manager1.ki, isNot(equals(manager2.ki)));
+      expect(manager1.kd, isNot(equals(manager2.kd)));
+    });
+
+    test('ゼロ誤差での制御入力計算', () {
+      final control = manager.computeControl(0.0);
+      expect(control, isA<double>());
+    });
+
+    test('負の誤差での制御入力計算', () {
+      final control = manager.computeControl(-1.0);
+      expect(control, isA<double>());
+      expect(control, lessThan(0.0)); // 負の誤差には負の制御入力
+    });
+
+    test('連続したステップでの動作確認', () {
+      final errors = [1.0, 0.8, 0.5, 0.2, 0.0];
+      final controls = <double>[];
+
+      for (final error in errors) {
+        controls.add(manager.computeControl(error));
+      }
+
+      // 誤差が減少していくので、制御入力も減少傾向
+      expect(controls.length, 5);
+      expect(controls.first, greaterThan(controls.last));
+    });
+  });
+}


### PR DESCRIPTION
## 実装内容

Simulator クラスから履歴管理ロジックを分離し、HistoryManager として独立させることで、責務の明確化とテスト容易性を向上させました。

Implements #34

## 変更内容

### 新規追加

- **lib/simulation/history_manager.dart**
  - 履歴8リスト（target, output, control, estimatedA/B, estimatedA1/A2/B1/B2）を管理
  - maxLength超過時の自動トリミング機能
  - 全クリア（clearAll()）とRLS推定値のみクリア（clearRlsEstimates()）の2種類のクリア方法

- **test/simulation/history_manager_test.dart**
  - 11個のテストケースで100%カバレッジ達成
  - 自動トリミング、クリア操作、基本履歴とRLS履歴の独立性を検証

### リファクタリング

- **lib/simulation/simulator.dart**
  - 履歴リストフィールド削除 → HistoryManager に委譲
  - UI互換性維持のための履歴アクセス用ゲッター追加
  - step() メソッドの簡潔化（約35行削減）
  - reset() メソッドの簡潔化（履歴クリアが1行に）

## 期待される効果

- コード削減：Simulator.step() で約35行削減
- 単一責任：履歴管理ロジックを独立
- テスト容易性：HistoryManager 単体でテスト可能
- テスト数：142 → 153 (+11)

## テスト結果

全テスト成功（153/153）で警告なし、フォーマット完全。

## チェックリスト

- [x] 実装完了
- [x] テスト追加（HistoryManager 用11テスト）
- [x] 全テスト成功（153/153）
- [x] flutter analyze クリア（警告0）
- [x] コードフォーマット適用
- [x] UI互換性維持
- [x] QUALITY_POLICY.md 準拠