### PR TITLE
fix: 外乱タイプドロップダウンを削除、プリセット選択のみに統一 (Issue #38)

### DIFF
--- a/lib/ui/components/disturbance_panel.dart
+++ b/lib/ui/components/disturbance_panel.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/material.dart';
-import '../../control/disturbance.dart';
 import '../../simulation/simulator.dart';
 
 /// 外乱設定パネル
 class DisturbancePanel extends StatelessWidget {
   final Simulator simulator;
-  final ValueChanged<DisturbanceType> onTypeChanged;
   final ValueChanged<String> onPresetApplied;
 
   const DisturbancePanel({
     super.key,
     required this.simulator,
-    required this.onTypeChanged,
     required this.onPresetApplied,
   });
 
@@ -30,46 +27,6 @@ class DisturbancePanel extends StatelessWidget {
               style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
-            // 外乱タイプドロップダウン
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text(
-                  '外乱タイプ',
-                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-                ),
-                DropdownButton<DisturbanceType>(
-                  value: simulator.disturbanceType,
-                  items: const [
-                    DropdownMenuItem(
-                      value: DisturbanceType.none,
-                      child: Text('なし'),
-                    ),
-                    DropdownMenuItem(
-                      value: DisturbanceType.step,
-                      child: Text('ステップ'),
-                    ),
-                    DropdownMenuItem(
-                      value: DisturbanceType.impulse,
-                      child: Text('インパルス'),
-                    ),
-                    DropdownMenuItem(
-                      value: DisturbanceType.sinusoid,
-                      child: Text('正弦波'),
-                    ),
-                    DropdownMenuItem(
-                      value: DisturbanceType.noise,
-                      child: Text('雑音'),
-                    ),
-                  ],
-                  onChanged: (v) {
-                    if (v == null) return;
-                    onTypeChanged(v);
-                  },
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
             // 現在のプリセット表示
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/ui/main_screen.dart
+++ b/lib/ui/main_screen.dart
@@ -212,11 +212,6 @@ class _MainScreenState extends State<MainScreen> {
               // === 外乱設定 ===
               DisturbancePanel(
                 simulator: simulator,
-                onTypeChanged: (type) {
-                  setState(() {
-                    simulator.setDisturbanceType(type);
-                  });
-                },
                 onPresetApplied: (presetName) {
                   setState(() {
                     simulator.applyDisturbancePreset(presetName);


### PR DESCRIPTION
## 概要

外乱タイプのドロップダウンとプリセット選択が併存しUI混乱を招いていたため、プリセット選択のみに統一しました。

## 変更内容

### lib/ui/components/disturbance_panel.dart
- 外乱タイプのドロップダウンUI削除（33-72行目）
- onTypeChanged コールバック削除
- DisturbanceType import 削除（不要になったため）

### lib/ui/main_screen.dart
- DisturbancePanel 呼び出しから onTypeChanged コールバック削除

## 影響範囲

- UI がシンプル化され、プリセットボタンのみで外乱選択が完結
- 外乱タイプを手動で選択する機能は削除（プリセットが代替）

## テスト結果

- flutter analyze: 0 warnings
- flutter test: 186/186 tests passed

## スクリーンショット

（必要に応じて追加）

Fixes #38
