### PR TITLE
fix: STR制御の極配置制御則が定常状態の出力に影響を与えている

### DIFF
--- a/lib/control/str.dart
+++ b/lib/control/str.dart
@@ -66,20 +66,25 @@ class STR {
     return clamped;
   }
 
-  /// 1次プラント用制御則（極配置）
-  /// u(k) = (r(k) - (a - p_d)*y(k)) / b
+  /// 1次プラント用制御則（極配置 + リファレンスゲイン）
+  /// u(k) = ((1 - p_d) * r(k) - (a - p_d) * y(k)) / b
+  /// ※ (1 - p_d) がリファレンスゲイン（DCゲインを1に補正）
   double _computeControl1st(double a, double b, double y, double r) {
     // b=0の場合は安全のため0を返す
     if (b.abs() < 1e-8) {
       return 0.0;
     }
 
-    final numerator = r - (a - targetPole1) * y;
+    final numerator = (1 - targetPole1) * r - (a - targetPole1) * y;
     return numerator / b;
   }
 
-  /// 2次プラント用制御則（極配置）
-  /// u(k) = (1/b1) * [r(k) - (a1 - p1 - p2)*y(k) - (a2 - p1*p2)*y(k-1) - b2*u(k-1)]
+  /// 2次プラント用制御則（極配置 + リファレンスゲイン）
+  /// u(k) = (1/b1) * [ (1 - p1 - p2 - p1*p2) * r(k)
+  ///                 - (a1 - (p1 + p2)) * y(k)
+  ///                 - (a2 - p1*p2) * y(k-1)
+  ///                 - b2 * u(k-1) ]
+  /// ※ (1 - p1 - p2 - p1*p2) がリファレンスゲイン（DCゲインを1に補正）
   double _computeControl2nd(
     double a1,
     double a2,
@@ -96,7 +101,7 @@ class STR {
     final p1p2Sum = targetPole1 + targetPole2;
     final p1p2Prod = targetPole1 * targetPole2;
 
-    final term1 = r;
+    final term1 = (1 - p1p2Sum - p1p2Prod) * r;
     final term2 = (a1 - p1p2Sum) * y;
     final term3 =
         (a2 - p1p2Prod) *

--- a/test/control/str_test.dart
+++ b/test/control/str_test.dart
@@ -1,7 +1,9 @@
 // STR (Self-Tuning Regulator) の単体テスト
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:adaptive_control_lab/control/plant.dart';
 import 'package:adaptive_control_lab/control/rls.dart';
+import 'package:adaptive_control_lab/control/second_order_plant.dart';
 import 'package:adaptive_control_lab/control/str.dart';
 
 void main() {
@@ -56,10 +58,10 @@ void main() {
       test('基本的な制御入力計算', () {
         // 初期化後に目標値追従
         // y=0.5, r=1.0, a=0.8, b=0.5, p_d=0.5
-        // u = (r - (a - p_d)*y) / b = (1.0 - (0.8 - 0.5)*0.5) / 0.5
-        //   = (1.0 - 0.15) / 0.5 = 1.7
+        // u = ((1 - p_d)*r - (a - p_d)*y) / b
+        //   = ((1-0.5)*1.0 - (0.8-0.5)*0.5) / 0.5 = 0.7
         final u = str1.computeControl(0.5, 1.0);
-        expect(u, closeTo(1.7, 0.01));
+        expect(u, closeTo(0.7, 0.01));
       });
 
       test('ゼロ目標値での制御', () {
@@ -82,16 +84,16 @@ void main() {
     group('制御則計算（2次系）', () {
       test('基本的な制御入力計算', () {
         // 1回目は履歴が空なので y(k-1), u(k-1) は0として計算される
-        // u1 = (1/0.5) * [1.0 - (0.8 - 0.8)*0.5 - (-0.3 - 0.15)*0 - 0.1*0]
-        //     = 2.0
+        // u1 = (1/0.5) * [(1 - p1 - p2 - p1*p2)*r - (a1 - p1 - p2)*y]
+        //     = (1/0.5) * [0.05 - 0] = 0.1
         final u1 = str2.computeControl(0.5, 1.0);
-        expect(u1, closeTo(2.0, 0.01));
+        expect(u1, closeTo(0.1, 0.01));
 
-        // 2回目は履歴が更新され、y(k-1)=0.5, u(k-1)=u1=2.0 を用いる
-        // u2 = (1/0.5) * [1.0 - (0.8 - 0.8)*0.3 - (-0.3 - 0.15)*0.5 - 0.1*2.0]
-        //     = 2.05
+        // 2回目は履歴が更新され、y(k-1)=0.5, u(k-1)=u1 を用いる
+        // u2 = (1/0.5) * [0.05 - 0 - (-0.45)*0.5 - 0.1*u1]
+        //     ≈ 0.53
         final u2 = str2.computeControl(0.3, 1.0);
-        expect(u2, closeTo(2.05, 0.01));
+        expect(u2, closeTo(0.53, 0.01));
       });
 
       test('b1=0に近い場合はセーフガード', () {
@@ -169,6 +171,49 @@ void main() {
         final u = str1.computeControl(0.5, 10.0);
         expect(u.isFinite, true);
         expect(u.abs(), lessThan(100)); // 妥当な制御入力
+      });
+    });
+
+    group('定常偏差の解消', () {
+      test('1次系: リファレンスゲインで定常偏差がほぼゼロ', () {
+        final plant = Plant(a: 0.8, b: 0.5);
+        final rls = RLS(
+          parameterCount: 2,
+          lambda: 1.0,
+          initialTheta: [plant.a, plant.b],
+        );
+        final str = STR(parameterCount: 2, rls: rls, targetPole1: 0.3);
+
+        const r = 1.0;
+        for (int k = 0; k < 80; k++) {
+          final u = str.computeControl(plant.output, r);
+          plant.step(u);
+        }
+
+        expect(plant.output, closeTo(r, 1e-3));
+      });
+
+      test('2次系: リファレンスゲインで定常偏差がほぼゼロ', () {
+        final plant = SecondOrderPlant(a1: 1.6, a2: -0.64, b1: 0.5, b2: 0.2);
+        final rls = RLS(
+          parameterCount: 4,
+          lambda: 1.0,
+          initialTheta: [plant.a1, plant.a2, plant.b1, plant.b2],
+        );
+        final str = STR(
+          parameterCount: 4,
+          rls: rls,
+          targetPole1: 0.4,
+          targetPole2: 0.3,
+        );
+
+        const r = 1.0;
+        for (int k = 0; k < 200; k++) {
+          final u = str.computeControl(plant.output, r);
+          plant.step(u);
+        }
+
+        expect(plant.output, closeTo(r, 1e-2));
       });
     });
 


### PR DESCRIPTION
## 実装内容

STR制御の極配置制御則にリファレンスゲイン（前置きゲイン）を追加し、閉ループシステムのDCゲインが1になるよう改修しました。これにより、ステップ目標に対する定常偏差が解消されます。

### 変更点

- **STR制御則の改修**
  - 1次系: `u(k) = ((1 - p_d) * r(k) - (a - p_d) * y(k)) / b`
  - 2次系: 前置きゲイン `(1 - p1 - p2 - p1*p2)` を目標値に乗算
  - 定常状態で目標値に完全に追従するよう設計

- **テストの拡張**
  - ユニットテスト期待値を新制御則に合わせて更新
  - 1次・2次システムのステップ目標追従テスト追加
  - 定常偏差がほぼゼロになることを検証（許容値: 1e-3以下）

### 関連Issue

Fixes #40

## テスト確認

- [x] `flutter analyze` - 0 issues
- [x] `flutter test test/control/str_test.dart` - 25/25 passed
- [x] 新しいテストケース「定常偏差の解消」を追加