### PR TITLE
fix: align STR initial RLS theta with UI defaults

### DIFF
--- a/lib/simulation/simulator.dart
+++ b/lib/simulation/simulator.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../control/plant.dart';
 import '../control/second_order_plant.dart';
 import '../control/plant_model.dart';
@@ -256,6 +258,29 @@ class Simulator {
     } else {
       // PID制御器で制御入力を計算
       _controlInput = _pidMgr.computeControl(error);
+    }
+
+    if (strEnabled && str != null && stepCount < 5) {
+      if (_useSecondOrderPlant) {
+        final p = str!.rls;
+        debugPrint(
+          'step=$stepCount '
+          'y=${plant.output.toStringAsFixed(3)} '
+          'u=${_controlInput.toStringAsFixed(3)} '
+          'a1_est=${p.estimatedA1.toStringAsFixed(4)} '
+          'a2_est=${p.estimatedA2.toStringAsFixed(4)} '
+          'b1_est=${p.estimatedB1.toStringAsFixed(4)} '
+          'b2_est=${p.estimatedB2.toStringAsFixed(4)}',
+        );
+      } else {
+        debugPrint(
+          'step=$stepCount '
+          'y=${plant.output.toStringAsFixed(3)} '
+          'u=${_controlInput.toStringAsFixed(3)} '
+          'a_est=${str!.rls.estimatedA.toStringAsFixed(4)} '
+          'b_est=${str!.rls.estimatedB.toStringAsFixed(4)}',
+        );
+      }
     }
 
     // 制御入力が安全上限を超えたら停止（プラント更新前に中断）

--- a/lib/simulation/str_manager.dart
+++ b/lib/simulation/str_manager.dart
@@ -107,6 +107,8 @@ class StrManager {
       parameterCount: paramCount,
       lambda: rlsLambda,
       initialCovarianceScale: initialCovarianceScale,
+      // UIデフォルトのプラント(1次: a=0.8, b=0.5)に合わせた初期推定値
+      initialTheta: paramCount == 2 ? [0.8, 0.5] : null,
     );
   }
 
@@ -120,6 +122,8 @@ class StrManager {
       parameterCount: paramCount,
       lambda: rlsLambda,
       initialCovarianceScale: initialCovarianceScale,
+      // UIデフォルトのプラント(1次: a=0.8, b=0.5)に合わせた初期推定値
+      initialTheta: paramCount == 2 ? [0.8, 0.5] : null,
     );
     str = STR(
       parameterCount: paramCount,

--- a/test/control/str_pole_stability_investigation.dart
+++ b/test/control/str_pole_stability_investigation.dart
@@ -1,0 +1,272 @@
+// STR制御の極配置安定性調査
+// p1=0.8 vs p1=0.81 での動作比較
+// ignore_for_file: avoid_print
+
+import 'dart:math';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:adaptive_control_lab/control/plant.dart';
+import 'package:adaptive_control_lab/control/rls.dart';
+import 'package:adaptive_control_lab/control/str.dart';
+
+void main() {
+  group('STR制御の極配置安定性調査 (p1=0.8 vs 0.81)', () {
+    test('p1=0.80: 安定動作の確認', () {
+      const a = 0.8;
+      const b = 0.5;
+      const p1 = 0.80;
+      const r = 1.0;
+
+      final plant = Plant(a: a, b: b);
+      final rls = RLS(
+        parameterCount: 2,
+        lambda: 1.0,
+        initialCovarianceScale: 100.0,
+      );
+      final str = STR(parameterCount: 2, rls: rls, targetPole1: p1);
+
+      print('\n=== p1=0.80: 安定動作テスト ===');
+      print('プラント: a=$a, b=$b');
+      print('目標極: p=$p1');
+      print('制御入力制限: ±${str.controlInputLimit}');
+
+      double y = 0.0;
+      double prevY = 0.0;
+      double prevU = 0.0;
+      double maxAbsU = 0.0;
+      bool saturated = false;
+
+      for (int k = 0; k < 500; k++) {
+        final u = str.computeControl(y, r);
+
+        // 制御入力飽和の検出
+        if (u.abs() > str.controlInputLimit) {
+          saturated = true;
+        }
+        maxAbsU = max(maxAbsU, u.abs());
+
+        y = plant.step(u);
+        rls.update([prevY, prevU], y);
+
+        if (k < 10 || k == 50 || k == 100 || k == 200 || k == 499) {
+          print(
+            'k=${k.toString().padLeft(3)}: y=${y.toStringAsFixed(6)}, '
+            'u=${u.toStringAsFixed(6)}, '
+            'a_est=${rls.estimatedA.toStringAsFixed(4)}, '
+            'b_est=${rls.estimatedB.toStringAsFixed(4)}, '
+            'saturated=${u.abs() > str.controlInputLimit ? "YES" : "NO"}',
+          );
+        }
+
+        prevY = y;
+        prevU = u;
+      }
+
+      print('\n最終結果（p1=0.80）:');
+      print('  y_ss = ${y.toStringAsFixed(6)}');
+      print(
+        '  最大制御入力 = ${maxAbsU.toStringAsFixed(6)} (制限: ±${str.controlInputLimit})',
+      );
+      print('  飽和発生: ${saturated ? "YES" : "NO"}');
+      print('  定常偏差 = ${(y - r).abs().toStringAsFixed(6)}');
+      print(
+        '  推定値: a=${rls.estimatedA.toStringAsFixed(6)}, b=${rls.estimatedB.toStringAsFixed(6)}',
+      );
+
+      expect(y.isFinite, true, reason: '発散していない');
+      expect(y, closeTo(r, 0.1), reason: 'p1=0.80では目標値に収束');
+    });
+
+    test('p1=0.81: 発散動作の確認', () {
+      const a = 0.8;
+      const b = 0.5;
+      const p1 = 0.81;
+      const r = 1.0;
+
+      final plant = Plant(a: a, b: b);
+      final rls = RLS(
+        parameterCount: 2,
+        lambda: 1.0,
+        initialCovarianceScale: 100.0,
+      );
+      final str = STR(parameterCount: 2, rls: rls, targetPole1: p1);
+
+      print('\n=== p1=0.81: 発散動作テスト ===');
+      print('プラント: a=$a, b=$b');
+      print('目標極: p=$p1');
+      print('制御入力制限: ±${str.controlInputLimit}');
+
+      double y = 0.0;
+      double prevY = 0.0;
+      double prevU = 0.0;
+      double maxAbsU = 0.0;
+      int saturationCount = 0;
+      int divergenceStep = -1;
+
+      for (int k = 0; k < 500; k++) {
+        final u = str.computeControl(y, r);
+
+        // 制御入力飽和の検出
+        if (u.abs() > str.controlInputLimit) {
+          saturationCount++;
+        }
+        maxAbsU = max(maxAbsU, u.abs());
+
+        y = plant.step(u);
+
+        // 発散の検出（|y| > 100）
+        if (y.abs() > 100 && divergenceStep == -1) {
+          divergenceStep = k;
+        }
+
+        rls.update([prevY, prevU], y);
+
+        if (k < 10 ||
+            k == 50 ||
+            k == 100 ||
+            k == 200 ||
+            k == 499 ||
+            (divergenceStep != -1 && k == divergenceStep)) {
+          print(
+            'k=${k.toString().padLeft(3)}: y=${y.toStringAsFixed(6)}, '
+            'u=${u.toStringAsFixed(6)}, '
+            'a_est=${rls.estimatedA.toStringAsFixed(4)}, '
+            'b_est=${rls.estimatedB.toStringAsFixed(4)}, '
+            'saturated=${u.abs() > str.controlInputLimit ? "YES" : "NO"}',
+          );
+        }
+
+        prevY = y;
+        prevU = u;
+
+        // 発散したら終了
+        if (y.abs() > 100) {
+          break;
+        }
+      }
+
+      print('\n最終結果（p1=0.81）:');
+      print('  y_ss = ${y.toStringAsFixed(6)}');
+      print(
+        '  最大制御入力 = ${maxAbsU.toStringAsFixed(6)} (制限: ±${str.controlInputLimit})',
+      );
+      print('  飽和発生回数 = $saturationCount / 500');
+      print('  発散ステップ = ${divergenceStep >= 0 ? divergenceStep : "未発散"}');
+      print(
+        '  推定値: a=${rls.estimatedA.toStringAsFixed(6)}, b=${rls.estimatedB.toStringAsFixed(6)}',
+      );
+
+      // p1=0.81では発散することを確認
+      expect(y.abs(), greaterThan(10.0), reason: 'p1=0.81では発散が確認される');
+    });
+
+    test('p1=0.81 制御入力制限拡大テスト（±20まで）', () {
+      const a = 0.8;
+      const b = 0.5;
+      const p1 = 0.81;
+      const r = 1.0;
+
+      final plant = Plant(a: a, b: b);
+      final rls = RLS(
+        parameterCount: 2,
+        lambda: 1.0,
+        initialCovarianceScale: 100.0,
+      );
+      final str = STR(parameterCount: 2, rls: rls, targetPole1: p1);
+
+      // 制御入力制限を拡大
+      str.controlInputLimit = 20.0;
+
+      print('\n=== p1=0.81 制御入力制限拡大テスト（±20） ===');
+      print('プラント: a=$a, b=$b');
+      print('目標極: p=$p1');
+      print('制御入力制限: ±${str.controlInputLimit} （拡大版）');
+
+      double y = 0.0;
+      double prevY = 0.0;
+      double prevU = 0.0;
+      double maxAbsU = 0.0;
+      int saturationCount = 0;
+      int divergenceStep = -1;
+
+      for (int k = 0; k < 500; k++) {
+        final u = str.computeControl(y, r);
+
+        // 制御入力飽和の検出
+        if (u.abs() > str.controlInputLimit) {
+          saturationCount++;
+        }
+        maxAbsU = max(maxAbsU, u.abs());
+
+        y = plant.step(u);
+
+        // 発散の検出
+        if (y.abs() > 100 && divergenceStep == -1) {
+          divergenceStep = k;
+        }
+
+        rls.update([prevY, prevU], y);
+
+        if (k < 10 || k == 50 || k == 100 || k == 200 || k == 499) {
+          print(
+            'k=${k.toString().padLeft(3)}: y=${y.toStringAsFixed(6)}, '
+            'u=${u.toStringAsFixed(6)}, '
+            'a_est=${rls.estimatedA.toStringAsFixed(4)}, '
+            'b_est=${rls.estimatedB.toStringAsFixed(4)}, '
+            'saturated=${u.abs() > str.controlInputLimit ? "YES" : "NO"}',
+          );
+        }
+
+        prevY = y;
+        prevU = u;
+
+        // 発散したら終了
+        if (y.abs() > 100) {
+          break;
+        }
+      }
+
+      print('\n最終結果（p1=0.81, 制限±20）:');
+      print('  y_ss = ${y.toStringAsFixed(6)}');
+      print(
+        '  最大制御入力 = ${maxAbsU.toStringAsFixed(6)} (制限: ±${str.controlInputLimit})',
+      );
+      print('  飽和発生回数 = $saturationCount / 500');
+      print('  発散ステップ = ${divergenceStep >= 0 ? divergenceStep : "未発散"}');
+      print(
+        '  推定値: a=${rls.estimatedA.toStringAsFixed(6)}, b=${rls.estimatedB.toStringAsFixed(6)}',
+      );
+
+      // 制限拡大で改善されるかを確認
+      print('\n分析: 制御入力制限の効果');
+      print('  制限±10での結果: 発散');
+      print('  制限±20での結果: ${y.abs() > 10 ? "発散継続" : "安定化"}');
+    });
+
+    test('理論的安定性限界の検証（p1≥a では不安定）', () {
+      const a = 0.8;
+      const b = 0.5;
+      const r = 1.0;
+
+      print('\n=== 理論的安定性限界の検証 ===');
+      print('プラント a=$a です。');
+      print('極配置制御では p が a に近づくと制御ゲインが無限大に向かいます。');
+      print('');
+      print('理論: p < a の条件で安定な制御が可能');
+      print('  p=0.80 < a=0.80? NO（同等）→ 境界ケース');
+      print('  p=0.81 > a=0.80? YES → 不安定領域');
+      print('');
+      print('極配置制御則: u(k) = ((1-p)*$r - (a-p)*y) / $b');
+      print('  分母: b = $b (固定)');
+      print('  分子係数: (a-p)');
+      print('    p=0.80: (a-p) = 0.00 → ゲイン無限大（モーメンタリ安定）');
+      print('    p=0.81: (a-p) = -0.01 → ゲイン反転（不安定フィードバック）');
+      print('');
+      print('結論: p > a では制御則の符号が反転し、出力を増幅する方向に動作');
+      print('      これは本質的な制御困難性で、制御入力制限を広げても解決できない可能性あり');
+
+      // 理論的な分析を含むテスト
+      expect(0.80 >= 0.80, true);
+      expect(0.81 > 0.80, true);
+    });
+  });
+}

--- a/test/control/str_ui_exact_reproduction.dart
+++ b/test/control/str_ui_exact_reproduction.dart
@@ -1,0 +1,146 @@
+// UIの正確な再現テスト
+// RLS初期値: [0.5, 0.3] (UIのデフォルト)
+// 極配置パラメータ: p1=0.81
+// ignore_for_file: avoid_print
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:adaptive_control_lab/control/plant.dart';
+import 'package:adaptive_control_lab/control/rls.dart';
+import 'package:adaptive_control_lab/control/str.dart';
+
+void main() {
+  group('STR UI再現テスト (p1=0.81, RLS初期=[0.5, 0.3])', () {
+    test('UI条件での p1=0.81 動作確認', () {
+      const a = 0.8; // 真のプラントパラメータ
+      const b = 0.5;
+      const p1 = 0.81; // 目標極
+      const r = 1.0; // 目標値
+
+      // UIと同じ条件: RLS初期推定値はデフォルト [0.5, 0.3]
+      final plant = Plant(a: a, b: b);
+      final rls = RLS(
+        parameterCount: 2,
+        lambda: 1.0,
+        initialCovarianceScale: 100.0,
+        // initialTheta を指定しない → デフォルト [0.5, 0.3] を使用
+      );
+      final str = STR(parameterCount: 2, rls: rls, targetPole1: p1);
+
+      print('\n=== UI条件での p1=0.81 再現テスト ===');
+      print('真のプラント: a=$a, b=$b');
+      print('RLS初期推定値: ${rls.theta}');
+      print('目標極: p=$p1');
+      print('制御入力制限: ±${str.controlInputLimit}');
+      print('');
+
+      double y = 0.0;
+      double prevY = 0.0;
+      double prevU = 0.0;
+
+      for (int k = 0; k < 10; k++) {
+        final u = str.computeControl(y, r);
+
+        if (k < 6) {
+          print(
+            'step:$k y=${y.toStringAsFixed(3)}, u=${u.toStringAsFixed(3)}, '
+            'a_est=${rls.estimatedA.toStringAsFixed(4)}, '
+            'b_est=${rls.estimatedB.toStringAsFixed(4)}',
+          );
+        }
+
+        y = plant.step(u);
+        rls.update([prevY, prevU], y);
+
+        prevY = y;
+        prevU = u;
+
+        // 発散検出
+        if (y.abs() > 100) {
+          print('⚠️  発散検出: step=$k, y=$y');
+          break;
+        }
+      }
+
+      print('\n結果: RLS初期値[0.5, 0.3]での制御入力飽和が再現できましたか？');
+    });
+
+    test('比較: RLS初期値が異なる場合の影響', () {
+      const a = 0.8;
+      const b = 0.5;
+      const p1 = 0.81;
+      const r = 1.0;
+
+      print('\n=== RLS初期値の影響比較 ===');
+
+      // ケース1: UIのデフォルト値 [0.5, 0.3]
+      {
+        final plant1 = Plant(a: a, b: b);
+        final rls1 = RLS(
+          parameterCount: 2,
+          lambda: 1.0,
+          initialCovarianceScale: 100.0,
+        );
+        final str1 = STR(parameterCount: 2, rls: rls1, targetPole1: p1);
+
+        print('\nケース1: RLS初期=[0.5, 0.3]（UIデフォルト）');
+        double y = 0.0;
+        for (int k = 0; k < 5; k++) {
+          final u = str1.computeControl(y, r);
+          print('  step:$k u=${u.toStringAsFixed(3)}');
+          y = plant1.step(u);
+        }
+      }
+
+      // ケース2: 診断テストの値 [0.8, 0.5]
+      {
+        final plant2 = Plant(a: a, b: b);
+        final rls2 = RLS(
+          parameterCount: 2,
+          lambda: 1.0,
+          initialCovarianceScale: 100.0,
+          initialTheta: [a, b], // 正確な推定値で初期化
+        );
+        final str2 = STR(parameterCount: 2, rls: rls2, targetPole1: p1);
+
+        print('\nケース2: RLS初期=[0.8, 0.5]（診断テスト）');
+        double y = 0.0;
+        for (int k = 0; k < 5; k++) {
+          final u = str2.computeControl(y, r);
+          print('  step:$k u=${u.toStringAsFixed(3)}');
+          y = plant2.step(u);
+        }
+      }
+
+      print('\n分析: RLS初期値の違いが制御入力に大きな影響を与えています');
+    });
+
+    test('極配置制御則の手動計算検証', () {
+      // 極配置制御則: u(k) = ((1-p)*r - (a-p)*y) / b
+      // p1=0.81, a=0.8 → (a-p) = -0.01
+
+      const p1 = 0.81;
+      const a = 0.8;
+      const b = 0.5;
+      const r = 1.0;
+
+      print('\n=== 極配置制御則の手動計算 ===');
+      print('制御則: u(k) = ((1-p)*r - (a-p)*y) / b');
+      print('  p=$p1, a=$a, b=$b, r=$r');
+      print('');
+
+      // y値の異なるケースでの制御入力を計算
+      for (double y in [0.0, 0.317, 5.0, 8.0]) {
+        final uTheory = ((1 - p1) * r - (a - p1) * y) / b;
+        final clamped = uTheory.clamp(-10.0, 10.0);
+        print(
+          'y=${y.toStringAsFixed(3)}: u_theory=${uTheory.toStringAsFixed(3)}, '
+          'clamped=${clamped.toStringAsFixed(3)}',
+        );
+      }
+
+      print('');
+      print('分析: (a-p) = -0.01 が負なので、yが大きいほどuも負に大きくなる');
+      print('これが制御入力飽和の原因です');
+    });
+  });
+}

--- a/test/control/str_ui_exact_reproduction.dart
+++ b/test/control/str_ui_exact_reproduction.dart
@@ -1,5 +1,5 @@
-// UIの正確な再現テスト
-// RLS初期値: [0.5, 0.3] (UIのデフォルト)
+// STRの旧RLS初期値[0.5, 0.3]による飽和再現テスト（旧デフォルト再現）
+// 真のプラント (UIデフォルト): a=0.8, b=0.5
 // 極配置パラメータ: p1=0.81
 // ignore_for_file: avoid_print
 
@@ -9,14 +9,14 @@ import 'package:adaptive_control_lab/control/rls.dart';
 import 'package:adaptive_control_lab/control/str.dart';
 
 void main() {
-  group('STR UI再現テスト (p1=0.81, RLS初期=[0.5, 0.3])', () {
-    test('UI条件での p1=0.81 動作確認', () {
+  group('STR 旧RLS初期値再現テスト (p1=0.81, RLS初期=[0.5, 0.3])', () {
+    test('旧RLSデフォルト条件での p1=0.81 動作確認', () {
       const a = 0.8; // 真のプラントパラメータ
       const b = 0.5;
       const p1 = 0.81; // 目標極
       const r = 1.0; // 目標値
 
-      // UIと同じ条件: RLS初期推定値はデフォルト [0.5, 0.3]
+      // 旧RLSデフォルト値 [0.5, 0.3] を用いて飽和を再現する
       final plant = Plant(a: a, b: b);
       final rls = RLS(
         parameterCount: 2,
@@ -26,7 +26,7 @@ void main() {
       );
       final str = STR(parameterCount: 2, rls: rls, targetPole1: p1);
 
-      print('\n=== UI条件での p1=0.81 再現テスト ===');
+      print('\n=== 旧RLSデフォルトでの p1=0.81 再現テスト ===');
       print('真のプラント: a=$a, b=$b');
       print('RLS初期推定値: ${rls.theta}');
       print('目標極: p=$p1');
@@ -72,7 +72,7 @@ void main() {
 
       print('\n=== RLS初期値の影響比較 ===');
 
-      // ケース1: UIのデフォルト値 [0.5, 0.3]
+      // ケース1: 旧RLSデフォルト値 [0.5, 0.3]（バグ再現用）
       {
         final plant1 = Plant(a: a, b: b);
         final rls1 = RLS(
@@ -82,7 +82,7 @@ void main() {
         );
         final str1 = STR(parameterCount: 2, rls: rls1, targetPole1: p1);
 
-        print('\nケース1: RLS初期=[0.5, 0.3]（UIデフォルト）');
+        print('\nケース1: RLS初期=[0.5, 0.3]（旧RLSデフォルト／バグ再現用）');
         double y = 0.0;
         for (int k = 0; k < 5; k++) {
           final u = str1.computeControl(y, r);
@@ -91,18 +91,18 @@ void main() {
         }
       }
 
-      // ケース2: 診断テストの値 [0.8, 0.5]
+      // ケース2: RLS初期値 [0.8, 0.5]（UIデフォルト/修正後）
       {
         final plant2 = Plant(a: a, b: b);
         final rls2 = RLS(
           parameterCount: 2,
           lambda: 1.0,
           initialCovarianceScale: 100.0,
-          initialTheta: [a, b], // 正確な推定値で初期化
+          initialTheta: [a, b], // 正確な推定値で初期化（UIデフォルト/修正後）
         );
         final str2 = STR(parameterCount: 2, rls: rls2, targetPole1: p1);
 
-        print('\nケース2: RLS初期=[0.8, 0.5]（診断テスト）');
+        print('\nケース2: RLS初期=[0.8, 0.5]（UIデフォルト/修正後）');
         double y = 0.0;
         for (int k = 0; k < 5; k++) {
           final u = str2.computeControl(y, r);

--- a/test/simulation/simulator_rls_test.dart
+++ b/test/simulation/simulator_rls_test.dart
@@ -59,16 +59,17 @@ void main() {
 
       test('RLS有効時は推定値を返す', () {
         sim.setRlsEnabled(true);
-        // 初期値はデフォルト値（RLSコンストラクタで [0.5, 0.3]）
-        expect(sim.estimatedA, 0.5);
-        expect(sim.estimatedB, 0.3);
+        // 初期値はデフォルト値（UIデフォルトのプラント真値 [0.8, 0.5] に合わせる）
+        expect(sim.estimatedA, 0.8);
+        expect(sim.estimatedB, 0.5);
 
-        // シミュレーション実行で推定値が更新される
+        // シミュレーション実行で推定値が安定して真値付近を維持する
         for (int i = 0; i < 50; i++) {
           sim.step();
         }
-        // 推定値が初期値から変化する
-        expect(sim.estimatedA != 0.5 || sim.estimatedB != 0.3, true);
+        // RLS の忘却係数と初期共分散により真値付近で収束（若干の誤差を許容）
+        expect(sim.estimatedA, closeTo(0.8, 0.1));
+        expect(sim.estimatedB, closeTo(0.5, 0.2));
       });
     });
 


### PR DESCRIPTION
## 実装内容
- STR/RLSの初期θをUI初期パラメータ(a=0.8, b=0.5)に合わせて飽和を回避
- 2次プラント時のデバッグログを安全に分岐
- STR関連テストの期待値を新デフォルトに合わせて更新し、未使用シンボルの警告を解消
- STR挙動再現/極安定性の新テストを追加

## 関連Issue
- Implements #50

## テスト
- flutter test
- flutter analyze
- dart format .