### PR TITLE
feat: シミュレーション最大ステップ数を1000に制限 (#63)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/lib/simulation/history_manager.dart
+++ b/lib/simulation/history_manager.dart
@@ -34,7 +34,7 @@ class HistoryManager {
   List<double> actualB2 = [];
 
   /// コンストラクタ
-  HistoryManager({this.maxLength = 5000});
+  HistoryManager({this.maxLength = 1000});
 
   /// 基本履歴（目標値、出力、制御入力）を追加
   void addStep({

--- a/lib/simulation/simulator.dart
+++ b/lib/simulation/simulator.dart
@@ -18,6 +18,8 @@ export 'disturbance_manager.dart' show DisturbancePreset;
 class Simulator {
   // 履歴上限（メモリ/パフォーマンス保護用）
   final int maxHistoryLength;
+  // シミュレーション最大ステップ数
+  final int maxSteps;
   // 安全ガード（発散防止の上限）
   final double maxOutputAbs;
   final double maxControlInputAbs;
@@ -48,7 +50,8 @@ class Simulator {
 
   /// コンストラクタ
   Simulator({
-    this.maxHistoryLength = 5000,
+    this.maxHistoryLength = 1000,
+    this.maxSteps = 1000,
     this.maxOutputAbs = 10.0,
     this.maxControlInputAbs = 10.0,
     this.rlsWarmupSteps = 10,
@@ -438,6 +441,11 @@ class Simulator {
           b: rls!.estimatedB,
         );
       }
+    }
+
+    // ステップ数上限に達したら停止
+    if (stepCount >= maxSteps) {
+      _halted = true;
     }
   }
 

--- a/lib/ui/main_screen.dart
+++ b/lib/ui/main_screen.dart
@@ -74,9 +74,21 @@ class _MainScreenState extends State<MainScreen> {
 
     // 50ms ごとにシミュレーションを進める
     simulationTimer = Timer.periodic(const Duration(milliseconds: 50), (_) {
-      setState(() {
-        simulator.step();
-      });
+      simulator.step();
+      if (simulator.isHalted) {
+        simulationTimer?.cancel();
+        final dataLength = simulator.historyTarget.length;
+        final maxScrollIndex = (dataLength - _effectiveChartWindow()).clamp(
+          0,
+          dataLength,
+        );
+        setState(() {
+          isRunning = false;
+          _scrollPosition = maxScrollIndex.toDouble();
+        });
+      } else {
+        setState(() {});
+      }
     });
   }
 

--- a/lib/ui/main_screen.dart
+++ b/lib/ui/main_screen.dart
@@ -74,6 +74,10 @@ class _MainScreenState extends State<MainScreen> {
 
     // 50ms ごとにシミュレーションを進める
     simulationTimer = Timer.periodic(const Duration(milliseconds: 50), (_) {
+      if (!mounted) {
+        simulationTimer?.cancel();
+        return;
+      }
       simulator.step();
       if (simulator.isHalted) {
         simulationTimer?.cancel();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -156,18 +156,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -257,10 +257,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/test/simulation/simulator_test.dart
+++ b/test/simulation/simulator_test.dart
@@ -252,6 +252,70 @@ void main() {
       expect(sim.historyTarget.length, historyLengthBefore);
     });
 
+    test('maxSteps到達で自動ハルトする', () {
+      final sim = Simulator(maxSteps: 5);
+
+      for (int i = 0; i < 10; i++) {
+        sim.step();
+        if (sim.isHalted) break;
+      }
+
+      expect(sim.isHalted, isTrue);
+      expect(sim.stepCount, 5);
+      expect(sim.historyTarget.length, 5);
+      expect(sim.historyOutput.length, 5);
+    });
+
+    test('maxSteps到達時は最終ステップのデータが記録される', () {
+      final sim = Simulator(maxSteps: 3);
+
+      for (int i = 0; i < 3; i++) {
+        sim.step();
+      }
+
+      // 3ステップ分のデータがすべて記録されていること
+      expect(sim.stepCount, 3);
+      expect(sim.historyOutput.length, 3);
+      // 最終出力値が記録されている（0でない）
+      expect(sim.historyOutput.last, isNonZero);
+    });
+
+    test('maxSteps到達後のstep呼び出しは何もしない', () {
+      final sim = Simulator(maxSteps: 5);
+
+      for (int i = 0; i < 5; i++) {
+        sim.step();
+      }
+
+      expect(sim.isHalted, isTrue);
+      final countBefore = sim.stepCount;
+      final historyLengthBefore = sim.historyTarget.length;
+
+      sim.step();
+      sim.step();
+
+      expect(sim.stepCount, countBefore);
+      expect(sim.historyTarget.length, historyLengthBefore);
+    });
+
+    test('reset後はmaxStepsハルトがクリアされ再実行できる', () {
+      final sim = Simulator(maxSteps: 5);
+
+      for (int i = 0; i < 5; i++) {
+        sim.step();
+      }
+      expect(sim.isHalted, isTrue);
+
+      sim.reset();
+
+      expect(sim.isHalted, isFalse);
+      expect(sim.stepCount, 0);
+
+      sim.step();
+      expect(sim.stepCount, 1);
+      expect(sim.isHalted, isFalse);
+    });
+
     test('reset後はhaltフラグがクリアされる', () {
       final sim = Simulator(maxControlInputAbs: 1.0);
 


### PR DESCRIPTION
## Summary

- `Simulator` に `maxSteps=1000` パラメータを追加し、上限到達で自動ハルト（最終ステップのデータは記録してから停止）
- `HistoryManager` / `Simulator` のデフォルトバッファを 5000 → 1000 に変更
- `main_screen.dart` のタイマーコールバックでハルト検知時にタイマーを自動キャンセルし、スクロール位置を最新データに更新
- `.gitignore` に `.claude/settings.local.json` を追加

## Test plan

- [ ] スタート後、1000ステップで自動停止することを確認
- [ ] 停止後にスクロール位置が最新データを指していることを確認
- [ ] 発散ハルト（maxOutputAbs超過）が従来通り動作することを確認
- [ ] PID・STR いずれのモードでも正常に停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)